### PR TITLE
Upgrade pyo3 to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Thin Python bindings to de/compression algorithms in Rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.9.0-alpha.1", features = ["extension-module"] }
+pyo3 = { version = "0.10.1", features = ["extension-module"] }
 snap = "^1"
 brotli2 = "^0.3"
 lz4-compress = "^0.1"


### PR DESCRIPTION
pyo3 0.10 added `catch_unwind!` macro to prevent panics crossing ffi boundaries https://github.com/PyO3/pyo3/pull/797 , which resolves #5, although ideally we should define some specific exceptions, but hey at least it's **not unsound** anymore.

```python
In [1]: import cramjam

In [2]: cramjam.snappy_decompress(b'abcdefgh')
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: StreamHeader { byte: 97 } }', src/snappy.rs:21:35
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
---------------------------------------------------------------------------
PanicException                            Traceback (most recent call last)
<ipython-input-2-1d4c0e441753> in <module>
----> 1 cramjam.snappy_decompress(b'abcdefgh')

PanicException: called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: StreamHeader { byte: 97 } }
```