### PR TITLE
Add appropriate python exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 license-file = "LICENSE"
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.10.1", features = ["extension-module"] }
 snap = "^1"
 brotli2 = "^0.3"
-lz4-compress = "^0.1"
+lz4 = "1"
 flate2 = "^1"
 zstd = "0.5.1+zstd.1.4.4"

--- a/src/brotli.rs
+++ b/src/brotli.rs
@@ -1,18 +1,19 @@
 use brotli2::read::{BrotliDecoder, BrotliEncoder};
+use std::error::Error;
 use std::io::prelude::*;
 
 /// Decompress via Brotli
-pub fn decompress(data: &[u8]) -> Vec<u8> {
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut decoder = BrotliDecoder::new(data);
     let mut buf = vec![];
-    decoder.read_to_end(&mut buf).unwrap();
-    buf
+    decoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }
 
 /// Compress via Brotli
-pub fn compress(data: &[u8], level: u32) -> Vec<u8> {
+pub fn compress(data: &[u8], level: u32) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut encoder = BrotliEncoder::new(data, level);
     let mut buf = vec![];
-    encoder.read_to_end(&mut buf).unwrap();
-    buf
+    encoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -1,19 +1,20 @@
 use flate2::read::{DeflateDecoder, DeflateEncoder};
 use flate2::Compression;
+use std::error::Error;
 use std::io::prelude::*;
 
 /// Decompress gzip data
-pub fn decompress(data: &[u8]) -> Vec<u8> {
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut decoder = DeflateDecoder::new(data);
     let mut buf = vec![];
-    decoder.read_to_end(&mut buf).unwrap();
-    buf
+    decoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }
 
 /// Compress gzip data
-pub fn compress(data: &[u8], level: u32) -> Vec<u8> {
+pub fn compress(data: &[u8], level: u32) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut buf = vec![];
     let mut encoder = DeflateEncoder::new(data, Compression::new(level));
-    encoder.read_to_end(&mut buf).unwrap();
-    buf
+    encoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,0 +1,5 @@
+use pyo3::create_exception;
+use pyo3::exceptions::Exception;
+
+create_exception!(cramjam, CompressionError, Exception);
+create_exception!(cramjam, DecompressionError, Exception);

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -1,19 +1,20 @@
 use flate2::read::{GzDecoder, GzEncoder};
 use flate2::Compression;
+use std::error::Error;
 use std::io::prelude::*;
 
 /// Decompress gzip data
-pub fn decompress(data: &[u8]) -> Vec<u8> {
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut decoder = GzDecoder::new(data);
     let mut buf = vec![];
-    decoder.read_to_end(&mut buf).unwrap();
-    buf
+    decoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }
 
 /// Compress gzip data
-pub fn compress(data: &[u8], level: u32) -> Vec<u8> {
+pub fn compress(data: &[u8], level: u32) -> Result<Vec<u8>, Box<dyn Error>> {
     let mut buf = vec![];
     let mut encoder = GzEncoder::new(data, Compression::new(level));
-    encoder.read_to_end(&mut buf).unwrap();
-    buf
+    encoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -1,9 +1,22 @@
+use std::error::Error;
+use std::io::{Read, Write};
+
 /// Decompress lz4 data
-pub fn decompress(data: &[u8]) -> Vec<u8> {
-    lz4_compress::decompress(data).unwrap()
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+    let mut decoder = lz4::Decoder::new(data)?;
+    let mut buf = vec![];
+    decoder.read_to_end(&mut buf)?;
+    let (_, result) = decoder.finish(); // Weird API...
+    result?;
+    Ok(buf)
 }
 
 /// Compress lz4 data
-pub fn compress(data: &[u8]) -> Vec<u8> {
-    lz4_compress::compress(data)
+pub fn compress(data: &[u8], level: u32) -> Result<Vec<u8>, Box<dyn Error>> {
+    let mut buf = vec![];
+    let mut encoder = lz4::EncoderBuilder::new().level(level).build(&mut buf)?;
+    encoder.write_all(data)?;
+    let (_, result) = encoder.finish(); // Weird API...
+    result?;
+    Ok(buf)
 }

--- a/src/snappy.rs
+++ b/src/snappy.rs
@@ -1,31 +1,31 @@
 use snap::raw::{Decoder, Encoder};
 use snap::read::{FrameDecoder, FrameEncoder};
-use std::io::Read;
+use std::io::{Error, Read};
 
 /// Decompress snappy data raw
-pub fn decompress_raw(data: &[u8]) -> Vec<u8> {
+pub fn decompress_raw(data: &[u8]) -> Result<Vec<u8>, snap::Error> {
     let mut decoder = Decoder::new();
-    decoder.decompress_vec(data).unwrap()
+    decoder.decompress_vec(data)
 }
 
 /// Compress snappy data raw
-pub fn compress_raw(data: &[u8]) -> Vec<u8> {
+pub fn compress_raw(data: &[u8]) -> Result<Vec<u8>, snap::Error> {
     let mut encoder = Encoder::new();
-    encoder.compress_vec(data).unwrap()
+    encoder.compress_vec(data)
 }
 
 /// Decompress snappy data framed
-pub fn decompress(data: &[u8]) -> Vec<u8> {
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Error> {
     let mut buf = vec![];
     let mut decoder = FrameDecoder::new(data);
-    decoder.read_to_end(&mut buf).unwrap();
-    buf
+    decoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }
 
 /// Decompress snappy data framed
-pub fn compress(data: &[u8]) -> Vec<u8> {
+pub fn compress(data: &[u8]) -> Result<Vec<u8>, Error> {
     let mut buf = vec![];
     let mut encoder = FrameEncoder::new(data);
-    encoder.read_to_end(&mut buf).unwrap();
-    buf
+    encoder.read_to_end(&mut buf)?;
+    Ok(buf)
 }

--- a/src/zstd.rs
+++ b/src/zstd.rs
@@ -1,9 +1,11 @@
+use std::io::Error;
+
 /// Decompress gzip data
-pub fn decompress(data: &[u8]) -> Vec<u8> {
-    zstd::stream::decode_all(data).unwrap()
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Error> {
+    zstd::stream::decode_all(data)
 }
 
 /// Compress gzip data
-pub fn compress(data: &[u8], level: i32) -> Vec<u8> {
-    zstd::stream::encode_all(data, level).unwrap()
+pub fn compress(data: &[u8], level: i32) -> Result<Vec<u8>, Error> {
+    zstd::stream::encode_all(data, level)
 }

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -1,6 +1,7 @@
 import pytest
 
 import cramjam
+from cramjam import DecompressionError, CompressionError
 
 
 @pytest.mark.parametrize(
@@ -18,3 +19,11 @@ def test_variants_simple(variant):
 
     decompressed = decompress(compressed)
     assert decompressed == uncompressed
+
+
+@pytest.mark.parametrize(
+    "variant", ("snappy", "brotli", "lz4", "gzip", "deflate", "zstd")
+)
+def test_variants_raise_exception(variant):
+    with pytest.raises(cramjam.DecompressionError):
+        getattr(cramjam, f"{variant}_decompress")(b'sknow')


### PR DESCRIPTION
Will close #7 

Adds `cramjam.DecompressionError` and `cramjam.CompressionError` exceptions, removes all `unwrap()`s