### PR TITLE
Support PyPy builds

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6]
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: 'x64'
+          architecture: x64
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -27,27 +27,49 @@ jobs:
           components: clippy
           override: true
 
-      - name: Python Dev Install
+      - name: Python Maturin Install
         run: |
           pip install --upgrade pip
-          pip install -r dev-requirements.txt
+          pip install maturin
 
-      - name: Build Wheels - Linux
-        if: startsWith(matrix.os, 'ubuntu')
+      - name: Build Wheels - Linux - CPython
+        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, 'pypy')  }}
         run: |
           docker run --rm -v $(pwd):/io konstin2/maturin build --release --out wheels
           ls -l wheels
 
-      - name: Build Wheels - Non-Linux
-        if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macos')
+      - name: Build Wheels - Windows and OSX - CPython
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, 'pypy') }}
         run: |
           pip install maturin
           maturin build --release --out wheels
           maturin sdist --out wheels
           ls -l wheels
 
-      - name: Install wheel
-        run: pip install cramjam --no-index --find-links wheels
+      - name: Build Wheels - Linux and OSX - PyPy
+        if: ${{ !startsWith(matrix.os, 'windows') && startsWith(matrix.python-version, 'pypy')  }}
+        run: |
+          make pypy-build
+          ls -l wheels
 
-      - name: Test
-        run: make test
+      # TODO: Windows PyPy not supported - ref: https://github.com/PyO3/maturin/issues/115
+      #- name: Build Wheels - Windows - PyPy
+      #  if: ${{ startsWith(matrix.os, 'windows') && startsWith(matrix.python-version, 'pypy')  }}
+      #  run: |
+      #    maturin build -i $(where pypy3) --release --out wheels --no-sdist
+      #    ls wheels
+
+      - name: Install wheel
+        if: ${{ !(startsWith(matrix.os, 'windows') && startsWith(matrix.python-version, 'pypy'))  }}
+        run: pip install cramjam --no-index --find-links wheels/
+
+      - name: Test - CPython
+        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
+        run: |
+          pip install --upgrade pip
+          pip install -r dev-requirements.txt
+          make test
+
+      - name: Test - PyPy
+        if: ${{ startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
+        run: pypy -c "import cramjam"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: ReleaseCI
 
 on:
   release:
+    types:
+      - published
+      - prereleased
   push:
     tags:
       - "*"
@@ -12,37 +15,46 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, pypy-3.6 ]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy
-        override: true
+      - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
 
-    - name: Install Dev requirements
-      run: |
-        pip install --upgrade pip
-        pip install -r dev-requirements.txt
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
 
-    - name: Build Wheels - Linux
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        docker run --rm -v $(pwd):/io konstin2/maturin build --release --out wheels
+      - name: Python Maturin Install
+        run: |
+          pip install --upgrade pip
+          pip install maturin
 
-    - name: Build Wheels - Non-Linux
-      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macos')
-      run: |
-        pip install maturin
-        maturin build --release --out wheels
-        maturin sdist --out wheels
+      - name: Build Wheels - Linux - CPython
+        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, 'pypy')  }}
+        run: |
+          docker run --rm -v $(pwd):/io konstin2/maturin build --release --out wheels
+          ls -l wheels
+
+      - name: Build Wheels - Windows and OSX - CPython
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, 'pypy') }}
+        run: |
+          pip install maturin
+          maturin build --release --out wheels
+          maturin sdist --out wheels
+          ls -l wheels
+
+      - name: Build Wheels - Linux and OSX - PyPy
+        if: ${{ !startsWith(matrix.os, 'windows') && startsWith(matrix.python-version, 'pypy')  }}
+        run: |
+          make pypy-build
+          ls -l wheels
 
     - name: Publish
       env:

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,8 @@ dev-install:
 	maturin build --release --out wheels --interpreter $(shell which python)
 	pip uninstall cramjam -y
 	rm wheels/*.tar.gz
-	pip install --no-index wheels/*
+	pip install cramjam --no-index --find-links wheels/
+
+pypy-build:
+	maturin build -i $(shell which pypy) --release --out wheels
+	pypy ./pypy_patch.py

--- a/pypy_patch.py
+++ b/pypy_patch.py
@@ -1,0 +1,26 @@
+import sysconfig
+import pathlib
+import re
+import sys
+
+"""
+Hacky hack, not very good support with maturin for PyPy
+
+1. Doesn't work on Windows
+2. The naming is wrong in resulting wheels in Linux & OSX
+
+This script patches the last issue; ran after normal maturin build for these
+systems on PyPy builds.
+"""
+
+abi = sysconfig.get_config_var("SOABI").replace("-", "_")
+major, minor = sys.version_info.major, sys.version_info.minor
+
+regex = re.compile(r"(?P<name>pp3[py0-9_]+-pypy[3_p0-9]+)")
+
+for file in pathlib.Path("./wheels").iterdir():
+    if file.name.endswith(".whl"):
+        new_name = regex.sub(f"pp{major}{minor}-{abi}", file.name)
+        new_name = new_name.replace("linux", "manylinux2010")
+        print(f"Renaming {file.name} -> {new_name}")
+        file.rename(file.parent.joinpath(new_name))


### PR DESCRIPTION
Adds PyPy36 support.

- Needs to run `pypy_patch.py` after builds until https://github.com/PyO3/maturin/issues/312 is closed
- Cannot support Windows PyPy until https://github.com/PyO3/maturin/issues/115 is closed