### PR TITLE
Rust file-like objects and accept bytes/bytearray/numpy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,6 @@ jobs:
         pip install maturin
         maturin build -i python --release --out dist --no-sdist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }}
         ' > build-wheel.sh
-        chmod +x build-wheel.sh
 
         docker run --rm -v "$PWD":/io -w /io quay.io/pypa/manylinux${{ matrix.platform.manylinux }}_${{ matrix.platform.arch }} bash build-wheel.sh
     - name: Python UnitTest
@@ -145,7 +144,7 @@ jobs:
         path: dist
 
   linux-cross:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         platform: [
@@ -157,32 +156,15 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.6
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: ${{ matrix.platform.target }}
-        profile: minimal
-        default: true
-    - name: Install aarch64 cross compiler
-      if: matrix.platform.target == 'aarch64-unknown-linux-gnu'
-      run: |
-        sudo apt-get install -y gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross
-        echo "TARGET_CC=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-        echo "TARGET_CXX=aarch64-linux-gnu-cpp" >> "$GITHUB_ENV"
-        echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-    - name: Install armv7 cross compiler
-      if: matrix.platform.target == 'armv7-unknown-linux-gnueabihf'
-      run: |
-        sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross
-        echo "TARGET_CC=arm-linux-gnueabihf-gcc" >> "$GITHUB_ENV"
-        echo "TARGET_CXX=arm-linux-gnueabihf-cpp" >> "$GITHUB_ENV"
-        echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> "$GITHUB_ENV"
-    - name: Install maturin
-      run: pip install maturin
     - name: Build Wheels
       run: |
-        maturin build -i python --release --out dist --no-sdist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} --cargo-extra-args="--no-default-features" --cargo-extra-args="--features=abi3"
+        echo 'curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+        source ~/.cargo/env
+        rustup target add ${{ matrix.platform.target }}
+        maturin build -i python --release --out dist --no-sdist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} --cargo-extra-args="--no-default-features" --cargo-extra-args="--features=abi3,extension-module"  # disable mimallocator
+        ' > build-wheel.sh
+
+        docker run --rm -v "$PWD":/io -w /io messense/manylinux2014-cross:${{ matrix.platform.arch }} bash build-wheel.sh
     - uses: uraimo/run-on-arch-action@v2.0.5
       name: Install built wheel
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,9 @@ jobs:
           profile: minimal
           default: true
       - name: Build
-        run: cargo build
+        run: cargo build --release
       - name: Tests
-        run: cargo test
+        run: cargo test --no-default-features --release
       - name: Install maturin
         run: pip install maturin
       - name: Build wheels - x86_64
@@ -78,10 +78,10 @@ jobs:
           default: true
       - name: Build
         if: matrix.platform.python-architecture == 'x64'
-        run: cargo build
+        run: cargo build --release
       - name: Tests
         if: matrix.platform.python-architecture == 'x64'
-        run: cargo test
+        run: cargo test --no-default-features --release
       - name: Install maturin
         run: pip install maturin
       - name: Build wheels
@@ -115,9 +115,9 @@ jobs:
         profile: minimal
         default: true
     - name: Build
-      run: cargo build
+      run: cargo build --release
     - name: Tests
-      run: cargo test
+      run: cargo test --no-default-features
     - uses: actions/setup-python@v2
       with:
         python-version: 3.6
@@ -220,9 +220,9 @@ jobs:
         profile: minimal
         default: true
     - name: Build
-      run: cargo build
+      run: cargo build --release
     - name: Tests
-      run: cargo test
+      run: cargo test --no-default-features
     - uses: actions/setup-python@v2
       with:
         python-version: pypy-3.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ opt-level = 3
 pyo3 = { version = "0.13.2", features = ["extension-module"] }
 snap = "^1"
 brotli2 = "^0.3"
-lz-fear = "0.1.1"
+lz4 = "^1"
 flate2 = "^1"
 zstd = "0.6.0+zstd.1.4.8"
 numpy = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 default = ["abi3", "mimallocator", "extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ codegen-units = 1
 opt-level = 3
 
 [dependencies]
-pyo3 = { version = "0.13.2" }
+pyo3 = { version = "0.13.2", default-features = false, features = ["macros"] }
 snap = "^1"
 brotli2 = "^0.3"
 lz4 = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam"
-version = "2.0.2"
+version = "2.1.0"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["abi3", "mimallocator"]
+default = ["abi3", "mimallocator", "extension-module"]
 abi3 = ["pyo3/abi3-py36"]
 mimallocator = ["mimalloc"]
+extension-module = ["pyo3/extension-module"]
 
 [profile.release]
 lto = "fat"
@@ -22,7 +23,7 @@ codegen-units = 1
 opt-level = 3
 
 [dependencies]
-pyo3 = { version = "0.13.2", features = ["extension-module"] }
+pyo3 = { version = "0.13.2" }
 snap = "^1"
 brotli2 = "^0.3"
 lz4 = "^1"

--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,5 @@ dev-install:
 	pip install cramjam --no-index --find-links dist/
 
 pypy-build:
-	maturin build -i $(shell which pypy) --release --out dist --cargo-extra-args="--no-default-features"  # disable abi3
+	maturin build -i $(shell which pypy) --release --out dist --cargo-extra-args="--no-default-features" --cargo-extra-args="--features=mimallocator,extension-module"  # disable abi3
 	pypy ./pypy_patch.py

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Where the API is `cramjam.<compression-variant>.compress/decompress` and accepts
 both `bytes` and `bytearray` objects.
 
 **de/compress_into**
-Additionally, support `decompress_into` and `compress_into`.
+Additionally, all variants support `decompress_into` and `compress_into`.
 If you have a numpy array preallocated, that can be used as the output location for de/compression.  
 Ex.
 ```python 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Where the API is `cramjam.<compression-variant>.compress/decompress` and accepts
 both `bytes` and `bytearray` objects.
 
 **de/compress_into**
-Additionally, all variants except for lz4, support `decompress_into` and `compress_into`.
+Additionally, support `decompress_into` and `compress_into`.
 If you have a numpy array preallocated, that can be used as the output location for de/compression.  
 Ex.
 ```python 

--- a/src/brotli.rs
+++ b/src/brotli.rs
@@ -1,3 +1,4 @@
+//! brotli de/compression interface
 use crate::exceptions::{CompressionError, DecompressionError};
 use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
@@ -6,7 +7,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
 use std::io::Cursor;
 
-pub fn init_py_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(decompress, m)?)?;
     m.add_function(wrap_pyfunction!(compress_into, m)?)?;

--- a/src/brotli.rs
+++ b/src/brotli.rs
@@ -1,6 +1,5 @@
 use crate::exceptions::{CompressionError, DecompressionError};
-use crate::{to_py_err, BytesType, WriteablePyByteArray};
-use numpy::PyArray1;
+use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
@@ -48,17 +47,19 @@ pub fn compress<'a>(
 #[pyfunction]
 pub fn compress_into<'a>(
     _py: Python<'a>,
-    data: BytesType<'a>,
-    array: &PyArray1<u8>,
+    input: BytesType<'a>,
+    mut output: BytesType<'a>,
     level: Option<u32>,
 ) -> PyResult<usize> {
-    crate::generic_into!(compress(data -> array), level)
+    let r = internal::compress(input, &mut output, level)?;
+    Ok(r)
 }
 
 /// Decompress directly into an output buffer
 #[pyfunction]
-pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyArray1<u8>) -> PyResult<usize> {
-    crate::generic_into!(decompress(data -> array))
+pub fn decompress_into<'a>(_py: Python<'a>, input: BytesType<'a>, mut output: BytesType<'a>) -> PyResult<usize> {
+    let r = internal::decompress(input, &mut output)?;
+    Ok(r)
 }
 
 pub(crate) mod internal {

--- a/src/brotli.rs
+++ b/src/brotli.rs
@@ -68,14 +68,14 @@ pub(crate) mod internal {
     use std::io::Error;
 
     /// Decompress via Brotli
-    pub fn decompress<W: Write + ?Sized>(input: &[u8], output: &mut W) -> Result<usize, Error> {
+    pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {
         let mut decoder = BrotliDecoder::new(input);
         let n_bytes = std::io::copy(&mut decoder, output)?;
         Ok(n_bytes as usize)
     }
 
     /// Compress via Brotli
-    pub fn compress<W: Write + ?Sized>(input: &[u8], output: &mut W, level: Option<u32>) -> Result<usize, Error> {
+    pub fn compress<W: Write + ?Sized, R: Read>(input: R, output: &mut W, level: Option<u32>) -> Result<usize, Error> {
         let level = level.unwrap_or_else(|| 11);
         let mut encoder = BrotliEncoder::new(input, level);
         let n_bytes = std::io::copy(&mut encoder, output)?;

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -69,14 +69,14 @@ pub(crate) mod internal {
     use std::io::Error;
 
     /// Decompress gzip data
-    pub fn decompress<W: Write + ?Sized>(input: &[u8], output: &mut W) -> Result<usize, Error> {
+    pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {
         let mut decoder = DeflateDecoder::new(input);
         let n_bytes = std::io::copy(&mut decoder, output)?;
         Ok(n_bytes as usize)
     }
 
     /// Compress gzip data
-    pub fn compress<W: Write + ?Sized>(input: &[u8], output: &mut W, level: Option<u32>) -> Result<usize, Error> {
+    pub fn compress<W: Write + ?Sized, R: Read>(input: R, output: &mut W, level: Option<u32>) -> Result<usize, Error> {
         let level = level.unwrap_or_else(|| 6);
 
         let mut encoder = DeflateEncoder::new(input, Compression::new(level));

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -1,6 +1,5 @@
 use crate::exceptions::{CompressionError, DecompressionError};
-use crate::{to_py_err, BytesType, WriteablePyByteArray};
-use numpy::PyArray1;
+use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
@@ -48,17 +47,19 @@ pub fn compress<'a>(
 #[pyfunction]
 pub fn compress_into<'a>(
     _py: Python<'a>,
-    data: BytesType<'a>,
-    array: &PyArray1<u8>,
+    input: BytesType<'a>,
+    mut output: BytesType<'a>,
     level: Option<u32>,
 ) -> PyResult<usize> {
-    crate::generic_into!(compress(data -> array), level)
+    let r = internal::compress(input, &mut output, level)?;
+    Ok(r)
 }
 
 /// Decompress directly into an output buffer
 #[pyfunction]
-pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyArray1<u8>) -> PyResult<usize> {
-    crate::generic_into!(decompress(data -> array))
+pub fn decompress_into<'a>(_py: Python<'a>, input: BytesType<'a>, mut output: BytesType<'a>) -> PyResult<usize> {
+    let r = internal::decompress(input, &mut output)?;
+    Ok(r)
 }
 
 pub(crate) mod internal {

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -1,3 +1,4 @@
+//! deflate de/compression interface
 use crate::exceptions::{CompressionError, DecompressionError};
 use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
@@ -6,7 +7,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
 use std::io::Cursor;
 
-pub fn init_py_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(decompress, m)?)?;
     m.add_function(wrap_pyfunction!(compress_into, m)?)?;

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,3 +1,4 @@
+//! cramjam specific Python exceptions
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -2,5 +2,8 @@
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 
+/// Raised during any error which occurs during compression
 create_exception!(cramjam, CompressionError, PyException);
+
+/// Raised during any error which occurs during decompression
 create_exception!(cramjam, DecompressionError, PyException);

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,9 +1,7 @@
+#![allow(missing_docs)]
 //! cramjam specific Python exceptions
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 
-/// Raised during any error which occurs during compression
 create_exception!(cramjam, CompressionError, PyException);
-
-/// Raised during any error which occurs during decompression
 create_exception!(cramjam, DecompressionError, PyException);

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -68,14 +68,14 @@ pub(crate) mod internal {
     use std::io::Error;
 
     /// Decompress gzip data
-    pub fn decompress<W: Write + ?Sized>(input: &[u8], output: &mut W) -> Result<usize, Error> {
+    pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {
         let mut decoder = GzDecoder::new(input);
         let n_bytes = std::io::copy(&mut decoder, output)?;
         Ok(n_bytes as usize)
     }
 
     /// Compress gzip data
-    pub fn compress<W: Write + ?Sized>(input: &[u8], output: &mut W, level: Option<u32>) -> Result<usize, Error> {
+    pub fn compress<W: Write + ?Sized, R: Read>(input: R, output: &mut W, level: Option<u32>) -> Result<usize, Error> {
         let level = level.unwrap_or_else(|| 6);
         let mut encoder = GzEncoder::new(input, Compression::new(level));
         let n_bytes = std::io::copy(&mut encoder, output)?;

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -1,6 +1,5 @@
 use crate::exceptions::{CompressionError, DecompressionError};
-use crate::{to_py_err, BytesType, WriteablePyByteArray};
-use numpy::PyArray1;
+use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
@@ -48,17 +47,19 @@ pub fn compress<'a>(
 #[pyfunction]
 pub fn compress_into<'a>(
     _py: Python<'a>,
-    data: BytesType<'a>,
-    array: &PyArray1<u8>,
+    input: BytesType<'a>,
+    mut output: BytesType<'a>,
     level: Option<u32>,
 ) -> PyResult<usize> {
-    crate::generic_into!(compress(data -> array), level)
+    let r = internal::compress(input, &mut output, level)?;
+    Ok(r)
 }
 
 /// Decompress directly into an output buffer
 #[pyfunction]
-pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyArray1<u8>) -> PyResult<usize> {
-    crate::generic_into!(decompress(data -> array))
+pub fn decompress_into<'a>(_py: Python<'a>, input: BytesType<'a>, mut output: BytesType<'a>) -> PyResult<usize> {
+    let r = internal::decompress(input, &mut output)?;
+    Ok(r)
 }
 
 pub(crate) mod internal {

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -1,3 +1,4 @@
+//! gzip de/compression interface
 use crate::exceptions::{CompressionError, DecompressionError};
 use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
@@ -6,7 +7,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
 use std::io::Cursor;
 
-pub fn init_py_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(decompress, m)?)?;
     m.add_function(wrap_pyfunction!(compress_into, m)?)?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -53,6 +53,9 @@ impl RustyFile {
         let r = Seek::seek(self, SeekFrom::Start(position as u64))?;
         Ok(r as usize)
     }
+    pub fn seekable(&self) -> bool {
+        true
+    }
     pub fn set_len(&mut self, size: usize) -> PyResult<()> {
         self.inner.set_len(size as u64)?;
         Ok(())
@@ -99,6 +102,12 @@ impl RustyBuffer {
         // TODO: Support SeekFrom from python side as in IOBase.seek definition
         let r = Seek::seek(self, SeekFrom::Start(position as u64))?;
         Ok(r as usize)
+    }
+    pub fn seekable(&self) -> bool {
+        true
+    }
+    pub fn tell(&self) -> usize {
+        self.inner.position() as usize
     }
     pub fn set_len(&mut self, size: usize) -> PyResult<()> {
         self.inner.get_mut().resize(size, 0);

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,64 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes};
+
+
+#[pyclass(name="File")]
+pub struct RustyFile {
+    inner: File, // preferably, this is R: Read, but generic structs cannot be exposed to Python
+}
+
+#[pymethods]
+impl RustyFile {
+    #[new]
+    pub fn new(
+        path: &str,
+        read: Option<bool>,
+        write: Option<bool>,
+        truncate: Option<bool>,
+        append: Option<bool>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: OpenOptions::new()
+                .read(read.unwrap_or_else(|| true))
+                .write(write.unwrap_or_else(|| true))
+                .truncate(truncate.unwrap_or_else(|| false))
+                .create(true) // create if doesn't exist, but open if it does.
+                .append(append.unwrap_or_else(|| false))
+                .open(path)?,
+        })
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> PyResult<usize> {
+        let r = self.inner.write(buf)?;
+        Ok(r)
+    }
+    pub fn read<'a>(&mut self, py: Python<'a>, n_bytes: Option<usize>) -> PyResult<&'a PyBytes> {
+        match n_bytes {
+            Some(n) => {
+                let mut buf = vec![0; n];
+                self.inner.read(buf.as_mut_slice())?;
+                Ok(PyBytes::new(py, buf.as_slice()))
+            }
+            None => {
+                let mut buf = vec![];
+                self.inner.read_to_end(&mut buf)?;
+                Ok(PyBytes::new(py, buf.as_slice()))
+            }
+        }
+    }
+    pub fn seek(&mut self, position: usize) -> PyResult<usize> {
+        let r = self.inner.seek(SeekFrom::Start(position as u64)).map(|r| r as usize)?;
+        Ok(r)
+    }
+    pub fn set_len(&mut self, size: usize) -> PyResult<()> {
+        self.inner.set_len(size as u64)?;
+        Ok(())
+    }
+    pub fn truncate(&mut self) -> PyResult<()> {
+        self.set_len(0)
+    }
+
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,13 +1,12 @@
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write, Cursor};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes};
+use pyo3::types::PyBytes;
 
-
-#[pyclass(name="File")]
+#[pyclass(name = "File")]
 pub struct RustyFile {
-    inner: File
+    inner: File,
 }
 
 #[pymethods]
@@ -62,7 +61,7 @@ impl RustyFile {
     }
 }
 
-#[pyclass(name="Buffer")]
+#[pyclass(name = "Buffer")]
 #[derive(Default)]
 pub struct RustyBuffer {
     inner: Cursor<Vec<u8>>,
@@ -72,7 +71,9 @@ pub struct RustyBuffer {
 impl RustyBuffer {
     #[new]
     pub fn new(len: Option<usize>) -> Self {
-        Self { inner: Cursor::new(vec![0; len.unwrap_or_else(|| 0)]) }
+        Self {
+            inner: Cursor::new(vec![0; len.unwrap_or_else(|| 0)]),
+        }
     }
 
     pub fn write(&mut self, buf: &[u8]) -> PyResult<usize> {
@@ -125,13 +126,13 @@ impl Write for RustyFile {
     }
 }
 
-impl Read for &mut RustyBuffer {
+impl Read for RustyBuffer {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.inner.read(buf)
     }
 }
 
-impl Read for &mut RustyFile {
+impl Read for RustyFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.inner.read(buf)
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -26,9 +26,6 @@ impl<'a> RustyNumpyArray<'a> {
     pub(crate) fn as_bytes(&self) -> &[u8] {
         unsafe { self.inner.as_slice().unwrap() }
     }
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        self.as_bytes()
-    }
 }
 impl<'a> From<&'a PyArray1<u8>> for RustyNumpyArray<'a> {
     fn from(inner: &'a PyArray1<u8>) -> Self {
@@ -130,11 +127,6 @@ impl<'a> RustyPyByteArray<'a> {
             inner,
             cursor: Cursor::new(unsafe { inner.as_bytes_mut() }),
         }
-    }
-    pub(crate) fn into_inner(mut self) -> PyResult<&'a PyByteArray> {
-        self.flush()
-            .map_err(|e| pyo3::exceptions::PyBufferError::new_err(e.to_string()))?;
-        Ok(self.inner)
     }
     pub(crate) fn as_bytes(&self) -> &[u8] {
         unsafe { self.inner.as_bytes() }

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,11 +3,184 @@ use std::io::{copy, Cursor, Read, Seek, SeekFrom, Write};
 
 use crate::BytesType;
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::types::{PyBytes, PyByteArray};
+use numpy::PyArray1;
+
+// Internal wrapper for PyArray1, to provide Read + Write and other traits
+pub struct RustyNumpyArray<'a> {
+    pub(crate) inner: &'a PyArray1<u8>,
+    pub(crate) cursor: Cursor<&'a mut [u8]>
+}
+impl<'a> RustyNumpyArray<'a> {
+    pub fn from_vec(py: Python<'a>, v: Vec<u8>) -> Self {
+        let inner = PyArray1::from_vec(py, v);
+        Self {
+            inner,
+            cursor: Cursor::new(unsafe {inner.as_slice_mut().unwrap() })
+        }
+    }
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { self.inner.as_slice().unwrap() }
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+impl<'a> From<&'a PyArray1<u8>> for RustyNumpyArray<'a> {
+    fn from(inner: &'a PyArray1<u8>) -> Self {
+        Self { inner, cursor: Cursor::new(unsafe { inner.as_slice_mut().unwrap() }) }
+    }
+}
+impl<'a> FromPyObject<'a> for RustyNumpyArray<'a> {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        let pybytes: &PyArray1<u8> = ob.extract()?;
+        Ok(Self::from(pybytes))
+    }
+}
+impl<'a> ToPyObject for RustyNumpyArray<'a> {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.inner.to_object(py)
+    }
+}
+impl<'a> Write for RustyNumpyArray<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.cursor.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.cursor.flush()
+    }
+}
+impl<'a> Read for RustyNumpyArray<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.cursor.read(buf)
+    }
+}
+
+impl<'a> Seek for RustyNumpyArray<'a> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.cursor.seek(pos)
+    }
+}
+
+// Internal wrapper for PyBytes, to provide Read + Write and other traits
+pub struct RustyPyBytes<'a> {
+    pub(crate) inner: &'a PyBytes,
+    pub(crate) cursor: Cursor<&'a mut [u8]>
+}
+impl<'a> RustyPyBytes<'a> {
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+impl<'a> From<&'a PyBytes> for RustyPyBytes<'a> {
+    fn from(inner: &'a PyBytes) -> Self {
+        let ptr = inner.as_bytes().as_ptr();
+        Self { inner, cursor: Cursor::new(unsafe { std::slice::from_raw_parts_mut(ptr as *mut _, inner.as_bytes().len()) }) }
+    }
+}
+impl<'a> FromPyObject<'a> for RustyPyBytes<'a> {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        let pybytes: &PyBytes = ob.extract()?;
+        Ok(Self::from(pybytes))
+    }
+}
+impl<'a> ToPyObject for RustyPyBytes<'a> {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.inner.to_object(py)
+    }
+}
+impl<'a> Read for RustyPyBytes<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.cursor.read(buf)
+    }
+}
+impl<'a> Write for RustyPyBytes<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.cursor.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.cursor.flush()
+    }
+}
+impl<'a> Seek for RustyPyBytes<'a> {
+    fn seek(&mut self, style: SeekFrom) -> std::io::Result<u64> {
+        self.cursor.seek(style)
+    }
+}
+
+// Internal wrapper for PyByteArray, to provide Read + Write and other traits
+pub struct RustyPyByteArray<'a> {
+    pub(crate) inner: &'a PyByteArray,
+    pub(crate) cursor: Cursor<&'a mut [u8]>,
+}
+impl<'a> RustyPyByteArray<'a> {
+    pub fn new(py: Python<'a>, len: usize) -> Self {
+        let inner = PyByteArray::new_with(py, len, |_| Ok(())).unwrap();
+        Self {
+            inner,
+            cursor: Cursor::new(unsafe { inner.as_bytes_mut() }),
+        }
+    }
+    pub fn into_inner(mut self) -> PyResult<&'a PyByteArray> {
+        self.flush()
+            .map_err(|e| pyo3::exceptions::PyBufferError::new_err(e.to_string()))?;
+        Ok(self.inner)
+    }
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { self.inner.as_bytes() }
+    }
+}
+impl<'a> From<&'a PyByteArray> for RustyPyByteArray<'a> {
+    fn from(inner: &'a PyByteArray) -> Self {
+        Self { inner, cursor: Cursor::new(unsafe { inner.as_bytes_mut() }) }
+    }
+}
+impl<'a> FromPyObject<'a> for RustyPyByteArray<'a> {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        let pybytes: &PyByteArray = ob.extract()?;
+        Ok(Self::from(pybytes))
+    }
+}
+impl<'a> ToPyObject for RustyPyByteArray<'a> {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.inner.to_object(py)
+    }
+}
+impl<'a> Write for RustyPyByteArray<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if (self.cursor.position() as usize + buf.len()) > self.inner.len() {
+            let previous_pos = self.cursor.position();
+            self.inner.resize(self.cursor.position() as usize + buf.len()).unwrap();
+            self.cursor = Cursor::new(unsafe { self.inner.as_bytes_mut() });
+            self.cursor.set_position(previous_pos);
+        }
+        self.cursor.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        if self.inner.len() != self.cursor.position() as usize {
+            let prev_pos = self.cursor.position();
+            self.inner.resize(self.cursor.position() as usize).unwrap();
+            self.cursor = Cursor::new(unsafe { self.inner.as_bytes_mut() });
+            self.cursor.set_position(prev_pos);
+        }
+        Ok(())
+    }
+}
+impl<'a> Read for RustyPyByteArray<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.cursor.read(buf)
+    }
+}
+
+impl<'a> Seek for RustyPyByteArray<'a> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.cursor.seek(pos)
+    }
+}
 
 #[pyclass(name = "File")]
 pub struct RustyFile {
-    pub(crate) inner: File,
+    pub inner: File,
 }
 
 #[pymethods]
@@ -134,10 +307,8 @@ fn write<W: Write>(input: &mut BytesType, output: &mut W) -> std::io::Result<u64
     let result = match input {
         BytesType::RustyFile(data) => copy(&mut data.borrow_mut().inner, output)?,
         BytesType::RustyBuffer(data) => copy(&mut data.borrow_mut().inner, output)?,
-        BytesType::ByteArray(data) => {
-            let mut array = Cursor::new(unsafe { data.as_bytes() });
-            copy(&mut array, output)?
-        }
+        BytesType::ByteArray(data) => copy(data, output)?,
+        BytesType::NumpyArray(array) => copy(array, output)?,
         BytesType::Bytes(data) => {
             let buffer = data.as_bytes();
             copy(&mut Cursor::new(buffer), output)?

--- a/src/io.rs
+++ b/src/io.rs
@@ -63,6 +63,7 @@ impl RustyFile {
 }
 
 #[pyclass(name="Buffer")]
+#[derive(Default)]
 pub struct RustyBuffer {
     inner: Cursor<Vec<u8>>,
 }
@@ -70,8 +71,8 @@ pub struct RustyBuffer {
 #[pymethods]
 impl RustyBuffer {
     #[new]
-    pub fn new(len: Option<usize>) -> PyResult<Self> {
-        Ok(Self { inner: Cursor::new(vec![0; len.unwrap_or_else(|| 0)]) })
+    pub fn new(len: Option<usize>) -> Self {
+        Self { inner: Cursor::new(vec![0; len.unwrap_or_else(|| 0)]) }
     }
 
     pub fn write(&mut self, buf: &[u8]) -> PyResult<usize> {
@@ -124,13 +125,13 @@ impl Write for RustyFile {
     }
 }
 
-impl Read for RustyBuffer {
+impl Read for &mut RustyBuffer {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.inner.read(buf)
     }
 }
 
-impl Read for RustyFile {
+impl Read for &mut RustyFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.inner.read(buf)
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -43,8 +43,18 @@ impl RustyFile {
         let r = copy(self, &mut out)?;
         Ok(r as usize)
     }
-    pub fn seek(&mut self, position: usize) -> PyResult<usize> {
-        let r = Seek::seek(self, SeekFrom::Start(position as u64))?;
+    pub fn seek(&mut self, position: isize, whence: Option<usize>) -> PyResult<usize> {
+        let pos = match whence.unwrap_or_else(|| 0) {
+            0 => SeekFrom::Start(position as u64),
+            1 => SeekFrom::Current(position as i64),
+            2 => SeekFrom::End(position as i64),
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "whence should be one of 0: seek from start, 1: seek from current, or 2: seek from end",
+                ))
+            }
+        };
+        let r = Seek::seek(self, pos)?;
         Ok(r as usize)
     }
     pub fn seekable(&self) -> bool {
@@ -85,9 +95,18 @@ impl RustyBuffer {
     pub fn read<'a>(&mut self, py: Python<'a>, n_bytes: Option<usize>) -> PyResult<&'a PyBytes> {
         read(self, py, n_bytes)
     }
-    pub fn seek(&mut self, position: usize) -> PyResult<usize> {
-        // TODO: Support SeekFrom from python side as in IOBase.seek definition
-        let r = Seek::seek(self, SeekFrom::Start(position as u64))?;
+    pub fn seek(&mut self, position: i64, whence: Option<usize>) -> PyResult<usize> {
+        let pos = match whence.unwrap_or_else(|| 0) {
+            0 => SeekFrom::Start(position as u64),
+            1 => SeekFrom::Current(position as i64),
+            2 => SeekFrom::End(position as i64),
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "whence should be one of 0: seek from start, 1: seek from current, or 2: seek from end",
+                ))
+            }
+        };
+        let r = Seek::seek(self, pos)?;
         Ok(r as usize)
     }
     pub fn seekable(&self) -> bool {

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,21 +2,21 @@ use std::fs::{File, OpenOptions};
 use std::io::{copy, Cursor, Read, Seek, SeekFrom, Write};
 
 use crate::BytesType;
-use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyByteArray};
 use numpy::PyArray1;
+use pyo3::prelude::*;
+use pyo3::types::{PyByteArray, PyBytes};
 
 // Internal wrapper for PyArray1, to provide Read + Write and other traits
 pub struct RustyNumpyArray<'a> {
     pub(crate) inner: &'a PyArray1<u8>,
-    pub(crate) cursor: Cursor<&'a mut [u8]>
+    pub(crate) cursor: Cursor<&'a mut [u8]>,
 }
 impl<'a> RustyNumpyArray<'a> {
     pub fn from_vec(py: Python<'a>, v: Vec<u8>) -> Self {
         let inner = PyArray1::from_vec(py, v);
         Self {
             inner,
-            cursor: Cursor::new(unsafe {inner.as_slice_mut().unwrap() })
+            cursor: Cursor::new(unsafe { inner.as_slice_mut().unwrap() }),
         }
     }
     pub fn as_bytes(&self) -> &[u8] {
@@ -28,7 +28,10 @@ impl<'a> RustyNumpyArray<'a> {
 }
 impl<'a> From<&'a PyArray1<u8>> for RustyNumpyArray<'a> {
     fn from(inner: &'a PyArray1<u8>) -> Self {
-        Self { inner, cursor: Cursor::new(unsafe { inner.as_slice_mut().unwrap() }) }
+        Self {
+            inner,
+            cursor: Cursor::new(unsafe { inner.as_slice_mut().unwrap() }),
+        }
     }
 }
 impl<'a> FromPyObject<'a> for RustyNumpyArray<'a> {
@@ -65,7 +68,7 @@ impl<'a> Seek for RustyNumpyArray<'a> {
 // Internal wrapper for PyBytes, to provide Read + Write and other traits
 pub struct RustyPyBytes<'a> {
     pub(crate) inner: &'a PyBytes,
-    pub(crate) cursor: Cursor<&'a mut [u8]>
+    pub(crate) cursor: Cursor<&'a mut [u8]>,
 }
 impl<'a> RustyPyBytes<'a> {
     pub fn as_bytes(&self) -> &[u8] {
@@ -75,7 +78,10 @@ impl<'a> RustyPyBytes<'a> {
 impl<'a> From<&'a PyBytes> for RustyPyBytes<'a> {
     fn from(inner: &'a PyBytes) -> Self {
         let ptr = inner.as_bytes().as_ptr();
-        Self { inner, cursor: Cursor::new(unsafe { std::slice::from_raw_parts_mut(ptr as *mut _, inner.as_bytes().len()) }) }
+        Self {
+            inner,
+            cursor: Cursor::new(unsafe { std::slice::from_raw_parts_mut(ptr as *mut _, inner.as_bytes().len()) }),
+        }
     }
 }
 impl<'a> FromPyObject<'a> for RustyPyBytes<'a> {
@@ -132,7 +138,10 @@ impl<'a> RustyPyByteArray<'a> {
 }
 impl<'a> From<&'a PyByteArray> for RustyPyByteArray<'a> {
     fn from(inner: &'a PyByteArray) -> Self {
-        Self { inner, cursor: Cursor::new(unsafe { inner.as_bytes_mut() }) }
+        Self {
+            inner,
+            cursor: Cursor::new(unsafe { inner.as_bytes_mut() }),
+        }
     }
 }
 impl<'a> FromPyObject<'a> for RustyPyByteArray<'a> {

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use pyo3::number::pos;
+
 
 #[pyclass(name = "File")]
 pub struct RustyFile {

--- a/src/io.rs
+++ b/src/io.rs
@@ -56,6 +56,10 @@ impl RustyFile {
     pub fn seekable(&self) -> bool {
         true
     }
+    pub fn tell(&mut self) -> PyResult<usize> {
+        let r = self.inner.seek(SeekFrom::Current(0))?;
+        Ok(r as usize)
+    }
     pub fn set_len(&mut self, size: usize) -> PyResult<()> {
         self.inner.set_len(size as u64)?;
         Ok(())

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,3 +1,7 @@
+//! Module holds native Rust objects exposed to Python, or objects
+//! which wrap native Python objects to provide additional functionality
+//! or tighter integration with de/compression algorithms.
+//!
 use std::fs::{File, OpenOptions};
 use std::io::{copy, Cursor, Read, Seek, SeekFrom, Write};
 
@@ -6,7 +10,7 @@ use numpy::PyArray1;
 use pyo3::prelude::*;
 use pyo3::types::{PyByteArray, PyBytes};
 
-// Internal wrapper for PyArray1, to provide Read + Write and other traits
+/// Internal wrapper for `numpy.array`/`PyArray1`, to provide Read + Write and other traits
 pub struct RustyNumpyArray<'a> {
     pub(crate) inner: &'a PyArray1<u8>,
     pub(crate) cursor: Cursor<&'a mut [u8]>,
@@ -65,7 +69,7 @@ impl<'a> Seek for RustyNumpyArray<'a> {
     }
 }
 
-// Internal wrapper for PyBytes, to provide Read + Write and other traits
+/// Internal wrapper for `bytes`/`PyBytes`, to provide Read + Write and other traits
 pub struct RustyPyBytes<'a> {
     pub(crate) inner: &'a PyBytes,
     pub(crate) cursor: Cursor<&'a mut [u8]>,
@@ -114,7 +118,7 @@ impl<'a> Seek for RustyPyBytes<'a> {
     }
 }
 
-// Internal wrapper for PyByteArray, to provide Read + Write and other traits
+/// Internal wrapper for `bytearray`/`PyByteArray`, to provide Read + Write and other traits
 pub struct RustyPyByteArray<'a> {
     pub(crate) inner: &'a PyByteArray,
     pub(crate) cursor: Cursor<&'a mut [u8]>,
@@ -187,9 +191,24 @@ impl<'a> Seek for RustyPyByteArray<'a> {
     }
 }
 
+/// A native Rust file-like object. Reading and writing takes place
+/// through the Rust implementation, allowing access to the underlying
+/// bytes in Python.
+///
+/// ### Python Example
+/// ```python
+/// from cramjam import File
+/// file = File("/tmp/file.txt")
+/// file.write(b"bytes")
+/// ```
+///
+/// ### Notes
+/// Presently, the file's handle is managed by Rust's lifetime rules, in that
+/// once it's garbage collected from Python's side, it will be closed.
+///
 #[pyclass(name = "File")]
 pub struct RustyFile {
-    pub inner: File,
+    pub(crate) inner: File,
 }
 
 #[pymethods]
@@ -255,6 +274,18 @@ impl RustyFile {
     }
 }
 
+/// A native Rust file-like object. Reading and writing takes place
+/// through the Rust implementation, allowing access to the underlying
+/// bytes in Python.
+///
+/// ### Python Example
+/// ```python
+/// >>> from cramjam import Buffer
+/// >>> buf = Buffer(b"bytes")
+/// >>> buf.read()
+/// b'bytes'
+/// ```
+///
 #[pyclass(name = "Buffer")]
 #[derive(Default)]
 pub struct RustyBuffer {

--- a/src/io.rs
+++ b/src/io.rs
@@ -264,10 +264,14 @@ pub struct RustyBuffer {
 #[pymethods]
 impl RustyBuffer {
     #[new]
-    pub fn new(len: Option<usize>) -> Self {
-        Self {
-            inner: Cursor::new(vec![0; len.unwrap_or_else(|| 0)]),
+    pub fn new(mut data: Option<BytesType<'_>>) -> PyResult<Self> {
+        let mut buf = vec![];
+        if let Some(bytes) = data.as_mut() {
+            bytes.read_to_end(&mut buf)?;
         }
+        Ok(Self {
+            inner: Cursor::new(buf),
+        })
     }
     pub fn write(&mut self, data: &PyAny) -> PyResult<usize> {
         let mut input = data.extract::<BytesType>()?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -130,9 +130,10 @@ fn write<W: Write>(input: &mut BytesType, output: &mut W) -> std::io::Result<u64
 fn read<'a, R: Read>(reader: &mut R, py: Python<'a>, n_bytes: Option<usize>) -> PyResult<&'a PyBytes> {
     match n_bytes {
         Some(n) => {
-            let mut buf = vec![0; n];
-            reader.read(buf.as_mut_slice())?;
-            Ok(PyBytes::new(py, buf.as_slice()))
+            PyBytes::new_with(py, n, |buf| {
+                reader.read(buf)?;
+                Ok(())
+            })
         }
         None => {
             let mut buf = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use pyo3::types::{PyByteArray, PyBytes};
 
 use crate::io::{RustyBuffer, RustyFile};
 use exceptions::{CompressionError, DecompressionError};
-use std::io::{Write, Seek, SeekFrom};
+use std::io::{Seek, SeekFrom, Write};
 
 #[cfg(feature = "mimallocator")]
 #[global_allocator]
@@ -125,7 +125,6 @@ impl<'a> Write for WriteablePyByteArray<'a> {
 
 impl<'a> Seek for WriteablePyByteArray<'a> {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-
         match pos {
             SeekFrom::Start(p) => self.position = p as usize,
             SeekFrom::Current(p) => {
@@ -134,7 +133,7 @@ impl<'a> Seek for WriteablePyByteArray<'a> {
                     next_pos = 0;
                 }
                 self.position = next_pos as usize;
-            },
+            }
             SeekFrom::End(p) => {
                 let mut next_pos = self.array.len() as i64 + p;
                 if next_pos < 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ fn cramjam(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("CompressionError", py.get_type::<CompressionError>())?;
     m.add("DecompressionError", py.get_type::<DecompressionError>())?;
     m.add_class::<crate::io::RustyFile>()?;
+    m.add_class::<crate::io::RustyBuffer>()?;
     make_submodule!(py -> m -> snappy);
     make_submodule!(py -> m -> brotli);
     make_submodule!(py -> m -> lz4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,43 @@
 //!  - [`cramjam.File`](io/struct.RustyFile.html)
 //!  - [`cramjam.Buffer`](./io/struct.RustyBuffer.html)
 //!
-//! Python Example:
+//! ### Simple Python Example:
 //!
 //! ```python
-//! data = b'some bytes here'
-//! compressed = cramjam.snappy.compress(data)
-//! decompressed = cramjam.snappy.decompress(compressed)
-//! assert data == decompressed
+//! >>> data = b'some bytes here'
+//! >>> compressed = cramjam.snappy.compress(data)
+//! >>> decompressed = cramjam.snappy.decompress(compressed)
+//! >>> assert data == decompressed
+//! >>>
+//! ```
+//!
+//! ### Example of de/compressing into different types.
+//!
+//! ```python
+//! >>> import numpy as np
+//! >>> from cramjam import snappy, Buffer
+//! >>>
+//! >>> data = np.frombuffer(b'some bytes here', dtype=np.uint8)
+//! >>> data
+//! array([115, 111, 109, 101,  32,  98, 121, 116, 101, 115,  32, 104, 101,
+//!        114, 101], dtype=uint8)
+//! >>>
+//! >>> compressed = Buffer()
+//! >>> snappy.compress_into(data, compressed)
+//! 33  # 33 bytes written to compressed buffer
+//! >>>
+//! >>> compressed.tell()  # Where is the buffer position?
+//! 33  # goodie!
+//! >>>
+//! >>> compressed.seek(0)  # Go back to the start of the buffer so we can prepare to decompress
+//! >>> decompressed = b'0' * len(data)  # let's write to `bytes` as output
+//! >>> decompressed
+//! b'000000000000000'
+//! >>>
+//! >>> snappy.decompress_into(compressed, decompressed)
+//! 15  # 15 bytes written to decompressed
+//! >>> decompressed
+//! b'some bytes here'
 //! ```
 
 pub mod brotli;
@@ -130,6 +160,7 @@ impl<'a> IntoPy<PyObject> for BytesType<'a> {
     }
 }
 
+/// Macro for generating the implementation of de/compression against a variant interface
 #[macro_export]
 macro_rules! generic {
     ($op:ident($input:expr), py=$py:ident, output_len=$output_len:ident $(, level=$level:ident)?) => {
@@ -204,6 +235,7 @@ macro_rules! generic {
     }
 }
 
+/// Macro to convert an error into a specific Python exception.
 #[macro_export]
 macro_rules! to_py_err {
     ($error:ident -> $expr:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod gzip;
 pub mod lz4;
 pub mod snappy;
 pub mod zstd;
+pub mod io;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyByteArray, PyBytes};
@@ -194,7 +195,7 @@ fn cramjam(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add("CompressionError", py.get_type::<CompressionError>())?;
     m.add("DecompressionError", py.get_type::<DecompressionError>())?;
-
+    m.add_class::<crate::io::RustyFile>()?;
     make_submodule!(py -> m -> snappy);
     make_submodule!(py -> m -> brotli);
     make_submodule!(py -> m -> lz4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
+#![warn(missing_docs)]
 //! CramJam documentation of python exported functions for (de)compression of bytes
 //!
-//! The API follows cramjam.`<<compression algorithm>>.compress` and cramjam.`<<compression algorithm>>.decompress`
+//! Although this documentation is built using Cargo/Rust toolchain, the examples and API represent
+//! the usable _Python_ API
+//!
+//! In general, the API follows cramjam.`<<compression algorithm>>.compress` and cramjam.`<<compression algorithm>>.decompress`
+//! as well as `compress_into`/`decompress_into` where it takes an input and output combination of any of the following:
+//!  - `numpy.array` (dtype=np.uint8)
+//!  - `bytes`
+//!  - `bytearray`
+//!  - [`cramjam.File`](io/struct.RustyFile.html)
+//!  - [`cramjam.Buffer`](./io/struct.RustyBuffer.html)
 //!
 //! Python Example:
 //!
@@ -10,13 +20,6 @@
 //! decompressed = cramjam.snappy.decompress(compressed)
 //! assert data == decompressed
 //! ```
-
-// TODO: There is a lot of very similar, but slightly different code for each variant
-// time should be spent perhaps with a macro or other alternative.
-// Each variant is similar, but sometimes has subtly different APIs/logic.
-
-// TODO: Add output size estimation for each variant, now it's just snappy
-// allow for resizing PyByteArray if over allocated; cannot resize PyBytes yet.
 
 pub mod brotli;
 pub mod deflate;
@@ -37,16 +40,24 @@ use std::io::{Read, Seek, SeekFrom, Write};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+/// Any possible input/output to de/compression algorithms.
+/// Typically, as a Python user, you never have to worry about this object. It's exposed here in
+/// the documentation to see what types are acceptable for de/compression functions.
 #[derive(FromPyObject)]
 pub enum BytesType<'a> {
+    /// `bytes`
     #[pyo3(transparent, annotation = "bytes")]
     Bytes(RustyPyBytes<'a>),
+    /// `bytearray`
     #[pyo3(transparent, annotation = "bytearray")]
     ByteArray(RustyPyByteArray<'a>),
+    /// `numpy.array` with `dtype=np.uint8`
     #[pyo3(transparent, annotation = "numpy")]
     NumpyArray(RustyNumpyArray<'a>),
+    /// [`cramjam.File`](io/struct.RustyFile.html)
     #[pyo3(transparent, annotation = "File")]
     RustyFile(&'a PyCell<RustyFile>),
+    /// [`cramjam.Buffer`](io/struct.RustyBuffer.html)
     #[pyo3(transparent, annotation = "Buffer")]
     RustyBuffer(&'a PyCell<RustyBuffer>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,11 @@ impl<'a> WriteablePyByteArray<'a> {
         Ok(self.array)
     }
 }
+impl<'a> From<&'a PyByteArray> for WriteablePyByteArray<'a> {
+    fn from(array: &'a PyByteArray) -> Self {
+        Self { array, position: 0 }
+    }
+}
 
 impl<'a> Write for WriteablePyByteArray<'a> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,28 @@ impl<'a> Write for WriteablePyByteArray<'a> {
 
 impl<'a> Seek for WriteablePyByteArray<'a> {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        unimplemented!();
-        Ok(0)
+
+        match pos {
+            SeekFrom::Start(p) => self.position = p as usize,
+            SeekFrom::Current(p) => {
+                let mut next_pos = self.position as i64 + p;
+                if next_pos < 0 {
+                    next_pos = 0;
+                }
+                self.position = next_pos as usize;
+            },
+            SeekFrom::End(p) => {
+                let mut next_pos = self.array.len() as i64 + p;
+                if next_pos < 0 {
+                    next_pos = 0;
+                }
+                self.position = next_pos as usize;
+            }
+        }
+        if self.position > self.array.len() {
+            self.array.resize(self.position)?;
+        }
+        Ok(self.position as u64)
     }
 }
 

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
-use std::io::{Cursor};
+use std::io::Cursor;
 
 pub fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
@@ -67,7 +67,7 @@ pub fn decompress_into<'a>(_py: Python<'a>, input: BytesType<'a>, mut output: By
 
 pub(crate) mod internal {
     use lz4::{Decoder, EncoderBuilder};
-    use std::io::{Error, Read, Seek, Write, SeekFrom};
+    use std::io::{Error, Read, Seek, SeekFrom, Write};
 
     /// Decompress lz4 data
     pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -1,3 +1,4 @@
+//! lz4 de/compression interface
 use crate::exceptions::{CompressionError, DecompressionError};
 use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
@@ -6,7 +7,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
 use std::io::Cursor;
 
-pub fn init_py_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(decompress, m)?)?;
     m.add_function(wrap_pyfunction!(compress_into, m)?)?;

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -66,7 +66,7 @@ pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyAr
 
 pub(crate) mod internal {
     use lz4::{Decoder, EncoderBuilder};
-    use std::io::{Error, Read, Write, Cursor, Seek, SeekFrom};
+    use std::io::{Error, Read, Write, Seek, SeekFrom};
 
     /// Decompress lz4 data
     pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -39,11 +39,11 @@ pub fn decompress<'a>(py: Python<'a>, data: BytesType<'a>, output_len: Option<us
 #[pyfunction]
 pub fn compress<'a>(
     py: Python<'a>,
-    data: BytesType<'a>,
+    mut data: BytesType<'a>,
     level: Option<u32>,
     output_len: Option<usize>,
 ) -> PyResult<BytesType<'a>> {
-    crate::generic!(compress(data), py = py, output_len = output_len, level = level)
+    crate::generic!(compress(&mut data), py = py, output_len = output_len, level = level)
 }
 
 /// Compress directly into an output buffer

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -66,7 +66,7 @@ pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyAr
 
 pub(crate) mod internal {
     use lz4::{Decoder, EncoderBuilder};
-    use std::io::{Error, Read, Write, Seek, SeekFrom};
+    use std::io::{Error, Read, Seek, SeekFrom, Write};
 
     /// Decompress lz4 data
     pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
-use std::io::{Cursor, Seek, SeekFrom};
+use std::io::{Cursor};
 
 pub fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
@@ -54,46 +54,8 @@ pub fn compress_into<'a>(
     mut output: BytesType<'a>,
     level: Option<u32>,
 ) -> PyResult<usize> {
-    // Unfortunately, lz4 only implements a the Read trait for its Encoder,
-    // meaning we will only get the bytes read, when we want the bytes written.
-    // it's too cumbersome to implement Seek for BytesType; as things like PyBytes doesn't
-    // really have a position; so we match each arm and create Cursor for &[u8] and normal seek
-    // for the internal rust types which have already implemented it.
-    let r = match &mut output {
-        BytesType::Bytes(pybytes) => {
-            let starting_pos = to_py_err!(CompressionError -> pybytes.cursor.seek(SeekFrom::Current(0)))?;
-            let _ = internal::compress(&mut input, pybytes, level)?;
-            let ending_pos = to_py_err!(CompressionError -> pybytes.cursor.seek(SeekFrom::Current(0)))?;
-            ending_pos - starting_pos
-        }
-        BytesType::ByteArray(pybytes) => {
-            let starting_pos = to_py_err!(CompressionError -> pybytes.cursor.seek(SeekFrom::Current(0)))?;
-            let _ = internal::compress(&mut input, pybytes, level)?;
-            let ending_pos = to_py_err!(CompressionError -> pybytes.cursor.seek(SeekFrom::Current(0)))?;
-            ending_pos - starting_pos
-        }
-        BytesType::NumpyArray(array) => {
-            let starting_pos = to_py_err!(CompressionError -> array.cursor.seek(SeekFrom::Current(0)))?;
-            internal::compress(&mut input, array, level)?;
-            let ending_pos = to_py_err!(CompressionError -> array.cursor.seek(SeekFrom::Current(0)))?;
-            ending_pos - starting_pos
-        }
-        BytesType::RustyFile(file) => {
-            let mut file_ref = file.borrow_mut();
-            let starting_pos = to_py_err!(CompressionError -> file_ref.inner.seek(SeekFrom::Current(0)))?;
-            let _ = internal::compress(&mut input, &mut file_ref.inner, level)?;
-            let ending_pos = to_py_err!(CompressionError -> file_ref.inner.seek(SeekFrom::Current(0)))?;
-            (ending_pos - starting_pos) as u64
-        }
-        BytesType::RustyBuffer(buffer) => {
-            let mut buf_ref = buffer.borrow_mut();
-            let starting_pos = buf_ref.inner.seek(SeekFrom::Current(0))?;
-            let _ = internal::compress(&mut input, &mut buf_ref.inner, level)?;
-            let ending_pos = buf_ref.inner.seek(SeekFrom::Current(0))?;
-            (ending_pos - starting_pos) as u64
-        }
-    };
-    Ok(r as usize)
+    let r = internal::compress(&mut input, &mut output, level)?;
+    Ok(r)
 }
 
 /// Decompress directly into an output buffer
@@ -105,7 +67,7 @@ pub fn decompress_into<'a>(_py: Python<'a>, input: BytesType<'a>, mut output: By
 
 pub(crate) mod internal {
     use lz4::{Decoder, EncoderBuilder};
-    use std::io::{Error, Read, Seek, Write};
+    use std::io::{Error, Read, Seek, Write, SeekFrom};
 
     /// Decompress lz4 data
     pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {
@@ -121,14 +83,18 @@ pub(crate) mod internal {
         output: &mut W,
         level: Option<u32>,
     ) -> Result<usize, Error> {
+        let start_pos = output.seek(SeekFrom::Current(0))?;
         let mut encoder = EncoderBuilder::new()
             .auto_flush(true)
             .level(level.unwrap_or_else(|| 4))
             .build(output)?;
 
-        let n_bytes = std::io::copy(input, &mut encoder)?;
-        let (_, r) = encoder.finish();
+        // this returns, bytes read from uncompressed, input; we want bytes written
+        // but lz4 only implements Read for Encoder
+        std::io::copy(input, &mut encoder)?;
+        let (w, r) = encoder.finish();
         r?;
-        Ok(n_bytes as usize)
+        let ending_pos = w.seek(SeekFrom::Current(0))?;
+        Ok((ending_pos - start_pos) as usize)
     }
 }

--- a/src/snappy.rs
+++ b/src/snappy.rs
@@ -1,3 +1,4 @@
+//! snappy de/compression interface
 use crate::exceptions::{CompressionError, DecompressionError};
 use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
@@ -6,7 +7,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
 use std::io::Cursor;
 
-pub fn init_py_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(decompress, m)?)?;
     m.add_function(wrap_pyfunction!(compress_raw, m)?)?;

--- a/src/zstd.rs
+++ b/src/zstd.rs
@@ -63,17 +63,17 @@ pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyAr
 
 pub(crate) mod internal {
 
-    use std::io::{Error, Write};
+    use std::io::{Error, Write, Read};
 
     /// Decompress gzip data
-    pub fn decompress<W: Write + ?Sized>(input: &[u8], output: &mut W) -> Result<usize, Error> {
+    pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {
         let mut decoder = zstd::stream::read::Decoder::new(input)?;
         let n_bytes = std::io::copy(&mut decoder, output)?;
         Ok(n_bytes as usize)
     }
 
     /// Compress gzip data
-    pub fn compress<W: Write + ?Sized>(input: &[u8], output: &mut W, level: Option<i32>) -> Result<usize, Error> {
+    pub fn compress<W: Write + ?Sized, R: Read>(input: R, output: &mut W, level: Option<i32>) -> Result<usize, Error> {
         let level = level.unwrap_or_else(|| 0); // 0 will use zstd's default, currently 11
         let mut encoder = zstd::stream::read::Encoder::new(input, level)?;
         let n_bytes = std::io::copy(&mut encoder, output)?;

--- a/src/zstd.rs
+++ b/src/zstd.rs
@@ -1,6 +1,5 @@
 use crate::exceptions::{CompressionError, DecompressionError};
-use crate::{to_py_err, BytesType, WriteablePyByteArray};
-use numpy::PyArray1;
+use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
@@ -48,17 +47,12 @@ pub fn compress<'a>(
 #[pyfunction]
 pub fn compress_into<'a>(
     _py: Python<'a>,
-    data: BytesType<'a>,
-    array: &PyArray1<u8>,
+    input: BytesType<'a>,
+    mut output: BytesType<'a>,
     level: Option<i32>,
 ) -> PyResult<usize> {
-    crate::generic_into!(compress(data -> array), level)
-}
-
-/// Decompress directly into an output buffer
-#[pyfunction]
-pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyArray1<u8>) -> PyResult<usize> {
-    crate::generic_into!(decompress(data -> array))
+    let r = internal::compress(input, &mut output, level)?;
+    Ok(r)
 }
 
 pub(crate) mod internal {
@@ -79,4 +73,11 @@ pub(crate) mod internal {
         let n_bytes = std::io::copy(&mut encoder, output)?;
         Ok(n_bytes as usize)
     }
+}
+
+/// Decompress directly into an output buffer
+#[pyfunction]
+pub fn decompress_into<'a>(_py: Python<'a>, input: BytesType<'a>, mut output: BytesType<'a>) -> PyResult<usize> {
+    let r = internal::decompress(input, &mut output)?;
+    Ok(r)
 }

--- a/src/zstd.rs
+++ b/src/zstd.rs
@@ -63,7 +63,7 @@ pub fn decompress_into<'a>(_py: Python<'a>, data: BytesType<'a>, array: &'a PyAr
 
 pub(crate) mod internal {
 
-    use std::io::{Error, Write, Read};
+    use std::io::{Error, Read, Write};
 
     /// Decompress gzip data
     pub fn decompress<W: Write + ?Sized, R: Read>(input: R, output: &mut W) -> Result<usize, Error> {

--- a/src/zstd.rs
+++ b/src/zstd.rs
@@ -1,3 +1,4 @@
+//! zstd de/compression interface
 use crate::exceptions::{CompressionError, DecompressionError};
 use crate::{to_py_err, BytesType};
 use pyo3::prelude::*;
@@ -6,7 +7,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::{PyResult, Python};
 use std::io::Cursor;
 
-pub fn init_py_module(m: &PyModule) -> PyResult<()> {
+pub(crate) fn init_py_module(m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(decompress, m)?)?;
     m.add_function(wrap_pyfunction!(compress_into, m)?)?;

--- a/tests/test_rust_io.py
+++ b/tests/test_rust_io.py
@@ -2,6 +2,7 @@ import pytest
 
 from cramjam import File, Buffer
 
+
 @pytest.mark.parametrize("Obj", (File, Buffer))
 def test_obj_api(tmpdir, Obj):
     if isinstance(Obj, File):
@@ -21,7 +22,12 @@ def test_obj_api(tmpdir, Obj):
     with pytest.raises(ValueError):
         buf.seek(1, 3)  # only 0, 1, 2 are valid seek from positions
 
-    for out in (b"12345", bytearray(b'12345'), File(str(tmpdir.join("test.txt"))), Buffer()):
+    for out in (
+        b"12345",
+        bytearray(b"12345"),
+        File(str(tmpdir.join("test.txt"))),
+        Buffer(),
+    ):
         buf.seek(0)
 
         expected = b"bytes"
@@ -40,12 +46,12 @@ def test_obj_api(tmpdir, Obj):
     # Set the length
     buf.set_len(2)
     buf.seek(0)
-    assert buf.read() == b'by'
+    assert buf.read() == b"by"
     buf.set_len(10)
     buf.seek(0)
-    assert buf.read() == b'by\x00\x00\x00\x00\x00\x00\x00\x00'
+    assert buf.read() == b"by\x00\x00\x00\x00\x00\x00\x00\x00"
 
     # truncate
     buf.truncate()
     buf.seek(0)
-    assert buf.read() == b''
+    assert buf.read() == b""

--- a/tests/test_rust_io.py
+++ b/tests/test_rust_io.py
@@ -1,4 +1,44 @@
 import pytest
 
-@pytest.mark.parametrize("Obj", (File, Obj))
-def test_obj(Obj)
+from cramjam import File, Buffer
+
+@pytest.mark.parametrize("Obj", (File, Buffer))
+def test_obj_api(tmpdir, Obj):
+    if isinstance(Obj, File):
+        buf = File(str(tmpdir.join("file.txt")))
+    else:
+        buf = Buffer()
+
+    assert buf.write(b"bytes") == 5
+    assert buf.tell() == 5
+    assert buf.seek(0) == 0
+    assert buf.read() == b"bytes"
+
+    for out in (b"12345", bytearray(b'12345'), File(str(tmpdir.join("test.txt"))), Buffer()):
+        buf.seek(0)
+
+        expected = b"bytes"
+
+        buf.readinto(out)
+
+        # Will update the output buffer
+        if isinstance(out, File) or isinstance(out, Buffer):
+            out.seek(0)
+            assert out.read() == expected
+        elif isinstance(out, bytearray):
+            assert out == bytearray(expected)
+        else:
+            assert out == expected
+
+    # Set the length
+    buf.set_len(2)
+    buf.seek(0)
+    assert buf.read() == b'by'
+    buf.set_len(10)
+    buf.seek(0)
+    assert buf.read() == b'by\x00\x00\x00\x00\x00\x00\x00\x00'
+
+    # truncate
+    buf.truncate()
+    buf.seek(0)
+    assert buf.read() == b''

--- a/tests/test_rust_io.py
+++ b/tests/test_rust_io.py
@@ -1,0 +1,4 @@
+import pytest
+
+@pytest.mark.parametrize("Obj", (File, Obj))
+def test_obj(Obj)

--- a/tests/test_rust_io.py
+++ b/tests/test_rust_io.py
@@ -13,6 +13,13 @@ def test_obj_api(tmpdir, Obj):
     assert buf.tell() == 5
     assert buf.seek(0) == 0
     assert buf.read() == b"bytes"
+    assert buf.seek(-1, 2) == 4  # set one byte backwards from end; position 4
+    assert buf.read() == b"s"
+    assert buf.seek(-2, whence=1) == 3  # set two bytes from current (end): position 3
+    assert buf.read() == b"es"
+
+    with pytest.raises(ValueError):
+        buf.seek(1, 3)  # only 0, 1, 2 are valid seek from positions
 
     for out in (b"12345", bytearray(b'12345'), File(str(tmpdir.join("test.txt"))), Buffer()):
         buf.seek(0)

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -7,9 +7,12 @@ import hashlib
 def same_same(a, b):
     return hashlib.md5(a).hexdigest() == hashlib.md5(b).hexdigest()
 
+
 def test_has_version():
     from cramjam import __version__
+
     assert isinstance(__version__, str)
+
 
 @pytest.mark.parametrize("is_bytearray", (True, False))
 @pytest.mark.parametrize(
@@ -85,3 +88,14 @@ def test_variant_snappy_raw_into():
     assert n_bytes == len(data)
 
     assert same_same(decompressed_buffer[:n_bytes], data)
+
+
+def test_native_buffer():
+    data = b"why, hello there! How do you do?" * 100000
+    input = cramjam.Buffer()
+    input.write(data)
+    input.seek(0)
+    compressed = cramjam.snappy.compress(input)
+    compressed.seek(0)
+
+    assert same_same(compressed.read(), cramjam.snappy.compress(data))

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -20,9 +20,6 @@ def test_has_version():
 )
 def test_variants_simple(variant_str, is_bytearray):
 
-    if variant_str == "lz4":
-        return  # TODO: Only until Seek is implemented for WritablePyByteArray
-
     variant = getattr(cramjam, variant_str)
 
     uncompressed = b"some bytes to compress 123" * 1000
@@ -47,7 +44,7 @@ def test_variants_raise_exception(variant_str):
         variant.decompress(b"sknow")
 
 
-@pytest.mark.parametrize("variant_str", ("snappy", "brotli", "gzip", "deflate", "zstd"))
+@pytest.mark.parametrize("variant_str", ("snappy", "brotli", "gzip", "deflate", "zstd", "lz4"))
 def test_variants_de_compress_into(variant_str):
 
     # TODO: support lz4 de/compress_into

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -20,6 +20,9 @@ def test_has_version():
 )
 def test_variants_simple(variant_str, is_bytearray):
 
+    if variant_str == "lz4":
+        return  # TODO: Only until Seek is implemented for WritablePyByteArray
+
     variant = getattr(cramjam, variant_str)
 
     uncompressed = b"some bytes to compress 123" * 1000

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -46,9 +46,6 @@ def test_variants_raise_exception(variant_str):
 
 @pytest.mark.parametrize("variant_str", ("snappy", "brotli", "gzip", "deflate", "zstd", "lz4"))
 def test_variants_de_compress_into(variant_str):
-
-    # TODO: support lz4 de/compress_into
-
     variant = getattr(cramjam, variant_str)
 
     data = b"oh what a beautiful morning, oh what a beautiful day!!" * 1000000


### PR DESCRIPTION
I think it would be cool to have file-like objects from the Rust side. This could allow side-stepping certain allocations to/from Python by allowing Rust to hold all the bytes. 

Most notably, compressing one file into another should be quite performant.
ie. 
```python
from cramjam import File, snappy
input_file = File("potentially-very-large-file.csv")
output_file = File("compressed-file.csv.snappy")
snappy.compress_into(input_file, output_file) 
```

and decompressing right into a buffer on the rust side:
```python
from cramjam import File, Buffer, snappy
input = File("some-file.csv.snappy")
decompressed = snappy.decompress(input)
decompressed.seek(0)
decompressed.read()  # decompressed bytes
```

- [x] Update `de/compress_into` to accept numpy array or these native types
- [x] Update documentation
- [x] Fix Rust tests
- [x] Update Python variant tests
- [x] ~Add some benchmarks for these types~ Not worth it, more convenience than drastically better performance.
- [x] May need to switch lz4 implementation for one that supports Read/Write traits
- [x] ~Probably make some common `FileLike` trait following [IOBase](https://docs.python.org/3/library/io.html#io.IOBase) interface~ `#[pymethods]` not supported for trait impls