### PR TITLE
Only fail on numpy import if using numpy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,6 +139,7 @@ jobs:
         pip install -r dev-requirements.txt
         make test
     - name: Test no numpy installed works
+      if: matrix.target == 'x86_64-unknown-linux-gnu'
       run: |
         pip uninstall numpy -y
         python -m pytest tests/test_no_numpy.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -138,6 +138,10 @@ jobs:
         pip install cramjam --no-index --find-links dist --force-reinstall
         pip install -r dev-requirements.txt
         make test
+    - name: Test no numpy installed works
+      run: |
+        pip uninstall numpy -y
+        python -m pytest tests/test_no_numpy.py
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 license-file = "LICENSE"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,15 +81,15 @@ pub enum BytesType<'a> {
     /// `bytearray`
     #[pyo3(transparent, annotation = "bytearray")]
     ByteArray(RustyPyByteArray<'a>),
-    /// `numpy.array` with `dtype=np.uint8`
-    #[pyo3(transparent, annotation = "numpy")]
-    NumpyArray(RustyNumpyArray<'a>),
     /// [`cramjam.File`](io/struct.RustyFile.html)
     #[pyo3(transparent, annotation = "File")]
     RustyFile(&'a PyCell<RustyFile>),
     /// [`cramjam.Buffer`](io/struct.RustyBuffer.html)
     #[pyo3(transparent, annotation = "Buffer")]
     RustyBuffer(&'a PyCell<RustyBuffer>),
+    /// `numpy.array` with `dtype=np.uint8`
+    #[pyo3(transparent, annotation = "numpy")]
+    NumpyArray(RustyNumpyArray<'a>)
 }
 
 impl<'a> AsBytes for BytesType<'a> {

--- a/tests/test_no_numpy.py
+++ b/tests/test_no_numpy.py
@@ -1,0 +1,23 @@
+import pytest
+import cramjam
+
+
+@pytest.mark.parametrize("obj", (bytes, bytearray, cramjam.Buffer, cramjam.File))
+@pytest.mark.parametrize(
+    "variant_str", ("snappy", "brotli", "lz4", "gzip", "deflate", "zstd")
+)
+def test_no_numpy_installed(tmpdir, obj, variant_str):
+    """
+    These operations should work even when numpy is not installed
+    """
+    if cramjam.File == obj:
+        data = obj(str(tmpdir.join("tmp.txt")))
+        data.write(b"data")
+        data.seek(0)
+    else:
+        data = obj(b"data")
+
+    variant = getattr(cramjam, variant_str)
+    compressed = variant.compress(data)
+    decompressed = variant.decompress(compressed)
+    assert decompressed.read() == b"data"


### PR DESCRIPTION
Will fix #56 

Seems the `FromPyObject` evaluates in the order of the enum variants. Placing numpy as the last variant in `BytesType` will alleviate the error mentioned in #56. 

- [x] Add CI test for this.