### PR TITLE
Support .flush for Compressor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cramjam"
-version = "2.4.0-rc1"
+version = "2.4.0-rc2"
 dependencies = [
  "brotli2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam"
-version = "2.4.0-rc1"
+version = "2.4.0-rc2"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 license = "MIT License"

--- a/src/brotli.rs
+++ b/src/brotli.rs
@@ -77,6 +77,11 @@ impl Compressor {
         crate::io::stream_compress(&mut self.inner, input)
     }
 
+    /// Flush and return current compressed stream
+    pub fn flush(&mut self) -> PyResult<RustyBuffer> {
+        crate::io::stream_flush(&mut self.inner, |e| e.get_mut())
+    }
+
     /// Consume the current compressor state and return the compressed stream
     /// **NB** The compressor will not be usable after this method is called.
     pub fn finish(&mut self) -> PyResult<RustyBuffer> {

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -78,6 +78,11 @@ impl Compressor {
         crate::io::stream_compress(&mut self.inner, input)
     }
 
+    /// Flush and return current compressed stream
+    pub fn flush(&mut self) -> PyResult<RustyBuffer> {
+        crate::io::stream_flush(&mut self.inner, |e| e.get_mut())
+    }
+
     /// Consume the current compressor state and return the compressed stream
     /// **NB** The compressor will not be usable after this method is called.
     pub fn finish(&mut self) -> PyResult<RustyBuffer> {

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -77,6 +77,11 @@ impl Compressor {
         crate::io::stream_compress(&mut self.inner, input)
     }
 
+    /// Flush and return current compressed stream
+    pub fn flush(&mut self) -> PyResult<RustyBuffer> {
+        crate::io::stream_flush(&mut self.inner, |e| e.get_mut())
+    }
+
     /// Consume the current compressor state and return the compressed stream
     /// **NB** The compressor will not be usable after this method is called.
     pub fn finish(&mut self) -> PyResult<RustyBuffer> {

--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -143,6 +143,15 @@ impl Compressor {
         crate::io::stream_compress(&mut self.inner, input)
     }
 
+    /// Flush and return current compressed stream
+    #[allow(mutable_transmutes)] // TODO: feature req to lz4 to get mut ref to writer
+    pub fn flush(&mut self) -> PyResult<RustyBuffer> {
+        crate::io::stream_flush(&mut self.inner, |e| {
+            let writer = e.writer();
+            unsafe { std::mem::transmute::<&Cursor<Vec<u8>>, &mut Cursor<Vec<u8>>>(writer) }
+        })
+    }
+
     /// Consume the current compressor state and return the compressed stream
     /// **NB** The compressor will not be usable after this method is called.
     pub fn finish(&mut self) -> PyResult<RustyBuffer> {

--- a/src/snappy.rs
+++ b/src/snappy.rs
@@ -144,6 +144,11 @@ impl Compressor {
         crate::io::stream_compress(&mut self.inner, input)
     }
 
+    /// Flush and return current compressed stream
+    pub fn flush(&mut self) -> PyResult<RustyBuffer> {
+        crate::io::stream_flush(&mut self.inner, |e| e.get_mut())
+    }
+
     /// Consume the current compressor state and return the compressed stream
     /// **NB** The compressor will not be usable after this method is called.
     pub fn finish(&mut self) -> PyResult<RustyBuffer> {

--- a/src/zstd.rs
+++ b/src/zstd.rs
@@ -76,6 +76,11 @@ impl Compressor {
         crate::io::stream_compress(&mut self.inner, input)
     }
 
+    /// Flush and return current compressed stream
+    pub fn flush(&mut self) -> PyResult<RustyBuffer> {
+        crate::io::stream_flush(&mut self.inner, |e| e.get_mut())
+    }
+
     /// Consume the current compressor state and return the compressed stream
     /// **NB** The compressor will not be usable after this method is called.
     pub fn finish(&mut self) -> PyResult<RustyBuffer> {

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -254,9 +254,14 @@ def test_gzip_multiple_streams():
 )
 def test_streams_compressor(mod):
     compressor = mod.Compressor()
+
     compressor.compress(b"foo")
+    out = bytes(compressor.flush())
+
     compressor.compress(b"bar")
-    out = compressor.finish()
+    out += bytes(compressor.flush())
+
+    out += bytes(compressor.finish())
     decompressed = mod.decompress(out)
     assert bytes(decompressed) == b"foobar"
 
@@ -266,4 +271,4 @@ def test_streams_compressor(mod):
 
     # compress will raise an error as the stream is completed
     with pytest.raises(cramjam.CompressionError):
-        compressor.compress(b'data')
+        compressor.compress(b"data")


### PR DESCRIPTION
#64 introduced streaming input, but of course, most will also want streaming output. :-)
Continues to follow the brotli API, such that flush will return what is currently compressed by the encoders and truncate its buff.

ie.
```python
>>> compressor = cramjam.snappy.Compressor()
>>> compressor.compress(b"foo")
>>> out = bytes(compressor.flush())
>>>
>>> compressor.compress(b"bar")
>>> out += bytes(compressor.flush())
>>>
>>> out += bytes(compressor.finish())
>>> decompressed = cramjam.snappy.decompress(out)
>>> assert bytes(decompressed) == b"foobar"
```

ref: https://github.com/developmentseed/starlette-cramjam/pull/1