### PR TITLE
Support Lz4 de/compress_block_into functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cramjam"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "brotli2",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cramjam"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -202,6 +202,7 @@ def test_variant_lz4_block_into(data):
     compressed_buffer = np.zeros(compressed_size, dtype=np.uint8)
     n_bytes = cramjam.lz4.compress_block_into(data, compressed_buffer)
     assert n_bytes == len(compressed)
+    assert same_same(compressed, compressed_buffer[:n_bytes])
 
     decompressed_buffer = np.zeros(len(data), dtype=np.uint8)
     n_bytes = cramjam.lz4.decompress_block_into(

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -190,6 +190,28 @@ def test_variant_snappy_raw_into(data):
     assert same_same(decompressed_buffer[:n_bytes], data)
 
 
+@given(data=st.binary())
+def test_variant_lz4_block_into(data):
+    """
+    A little more special than other de/compress_into variants, as the underlying
+    snappy raw api makes a hard expectation that its calculated len is used.
+    """
+
+    compressed = cramjam.lz4.compress_block(data)
+    compressed_size = cramjam.lz4.compress_block_bound(data)
+    compressed_buffer = np.zeros(compressed_size, dtype=np.uint8)
+    n_bytes = cramjam.lz4.compress_block_into(data, compressed_buffer)
+    assert n_bytes == len(compressed)
+
+    decompressed_buffer = np.zeros(len(data), dtype=np.uint8)
+    n_bytes = cramjam.lz4.decompress_block_into(
+        compressed_buffer[:n_bytes].tobytes(), decompressed_buffer
+    )
+    assert n_bytes == len(data)
+
+    assert same_same(decompressed_buffer[:n_bytes], data)
+
+
 @pytest.mark.parametrize("Obj", (cramjam.File, cramjam.Buffer))
 @given(data=st.binary())
 def test_dunders(Obj, tmp_path_factory, data):


### PR DESCRIPTION
[lz4](https://github.com/10XGenomics/lz4-rs) adds de/compress_block_into functionality, mentioned in https://github.com/10XGenomics/lz4-rs/issues/16

This adds the following functions:
- [`cramjam.lz4.compress_block_into`](https://docs.rs/lz4/1.23.3/lz4/block/fn.compress_to_buffer.html)
- [`cramjam.lz4.decompress_block_into`](https://docs.rs/lz4/1.23.3/lz4/block/fn.decompress_to_buffer.html)
- [`cramjam.lz4.compress_block_bound`](https://docs.rs/lz4/1.23.3/lz4/block/fn.compress_bound.html)