### PR TITLE
Simpler isinstance() calls

### DIFF
--- a/cramjam-python/benchmarks/test_bench.py
+++ b/cramjam-python/benchmarks/test_bench.py
@@ -211,7 +211,7 @@ def test_lz4_block(benchmark, file, use_cramjam: bool):
     [
         f
         for f in FILES
-        if not (isinstance(f, FiftyFourMbRandom) or isinstance(f, FiftyFourMbRepeating))
+        if not (isinstance(f, (FiftyFourMbRandom, FiftyFourMbRepeating))
     ],
     ids=lambda val: val.name,
 )

--- a/cramjam-python/tests/test_rust_io.py
+++ b/cramjam-python/tests/test_rust_io.py
@@ -35,7 +35,7 @@ def test_obj_api(tmpdir, Obj):
         buf.readinto(out)
 
         # Will update the output buffer
-        if isinstance(out, File) or isinstance(out, Buffer):
+        if isinstance(out, (File, Buffer)):
             out.seek(0)
             assert out.read() == expected
         elif isinstance(out, bytearray):


### PR DESCRIPTION
Supporting Python < 3.10 requires:
```python
	isinstance(x, (A, B))
```
instead of:
```python
	isinstance(x, A | B)
```