### PR TITLE
Use pyo3 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,8 +420,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.2"
-source = "git+https://github.com/PyO3/pyo3.git?rev=90cc69b#90cc69ba73eaad3567bd660db3f531bafaadf583"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -436,8 +437,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.2"
-source = "git+https://github.com/PyO3/pyo3.git?rev=90cc69b#90cc69ba73eaad3567bd660db3f531bafaadf583"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -445,8 +447,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.2"
-source = "git+https://github.com/PyO3/pyo3.git?rev=90cc69b#90cc69ba73eaad3567bd660db3f531bafaadf583"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -454,8 +457,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.2"
-source = "git+https://github.com/PyO3/pyo3.git?rev=90cc69b#90cc69ba73eaad3567bd660db3f531bafaadf583"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -465,8 +469,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.2"
-source = "git+https://github.com/PyO3/pyo3.git?rev=90cc69b#90cc69ba73eaad3567bd660db3f531bafaadf583"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/cramjam-python/Cargo.toml
+++ b/cramjam-python/Cargo.toml
@@ -18,6 +18,5 @@ extension-module = ["pyo3/extension-module"]
 
 
 [dependencies]
-# Python 3.12 support not officially released yet
-pyo3 = { git = "https://github.com/PyO3/pyo3.git", rev="90cc69b", default-features = false, features = ["macros"] }
+pyo3 = { version = "^0.20", default-features = false, features = ["macros"] }
 libcramjam = { path = "../libcramjam" }


### PR DESCRIPTION
This version has official support for Python 3.12:

https://github.com/PyO3/pyo3/releases/tag/v0.20.0